### PR TITLE
Use HL-color for marketplace BG, add haxe / hashlink tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,14 @@
 	"categories": [
 		"Debuggers"
 	],
-	"private": true,
+	"galleryBanner": {
+		"theme": "dark",
+		"color": "#5d338f"
+	},
+	"keywords": [
+		"haxe",
+		"hashlink"
+	],
 	"dependencies": {
 		"vscode-debugprotocol": "1.24.0",
 		"vscode-debugadapter": "1.24.0",


### PR DESCRIPTION
This improves the marketplace presentation a bit. Now the extension can actually be found with the `haxe` tag, such as all the others: https://marketplace.visualstudio.com/search?term=tag%3Ahaxe&target=VSCode&category=All%20categories&sortBy=Relevance

I also customized the banner BG color to match the color of HL's logo:

![](https://i.imgur.com/sSl88Zk.png)

(ignore the stretched out icon, I think that's just a bug in [Extension Manifest Editor](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.extension-manifest-editor)'s preview)